### PR TITLE
webpack-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-core": "^6.18.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
-    "webpack": "^1.12.14"
+    "webpack": "^2.2.1"
   },
   "babel": {
     "presets": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,12 @@ var webpack = require('webpack');
 
 module.exports = {
     entry: {
+        // entry point for your application code
         main: [
-            './src/app/main.js' // entry point for your application code
+            './src/app/main.js'
         ],
-        vendor: [
-            // put your third party libs here
-        ]
+        // put your third party libs here
+        // vendor: []
     },
     output: {
         filename: './dist/[name].bundle.js',
@@ -17,10 +17,10 @@ module.exports = {
         libraryTarget: 'amd'
     },
     resolve: {
-        extensions: ['', '.webpack.js', '.web.js', '.js', '.jsx']
+        extensions: ['.webpack.js', '.web.js', '.js', '.jsx']
     },
     module: {
-        loaders: [
+        rules: [
             // ES2015 files
             {
               test: /\.(js|jsx)$/,
@@ -29,7 +29,10 @@ module.exports = {
             // css
             {
                 test: /\.css$/,
-                loader: 'style-loader!css-loader'
+                use: [
+                  'style-loader',
+                  'css-loader'
+                ]
             }
         ]
     },


### PR DESCRIPTION
Thankfully this Webpack 2 [migration doc](https://webpack.js.org/guides/migrating/) made things a breeze.

@tomwayson if you want this on master, I think the README code urls will have to be updated in a couple spots:
- [x] https://github.com/tomwayson/esri-webpack-babel#how-it-works
- [x] https://github.com/tomwayson/esri-webpack-babel#integrating-with-other-libraries (there's also a couple spots where "lbraries" appears instead of "libraries")


cc @andygup